### PR TITLE
Remove mklink since it doesn't exit on diego cells

### DIFF
--- a/smb_mounter_windows.go
+++ b/smb_mounter_windows.go
@@ -71,6 +71,8 @@ func (m *smbMounter) Mount(env dockerdriver.Env, source string, target string, o
 		opts["password"].(string),
 		"-remotePath",
 		source,
+		"-localPath",
+		target,
 	}
 
 	logger.Debug("parse-mount", lager.Data{
@@ -83,23 +85,6 @@ func (m *smbMounter) Mount(env dockerdriver.Env, source string, target string, o
 
 	logger.Debug("mount", lager.Data{"params": strings.Join(mountOptions, ",")})
 	_, err := m.invoker.Invoke(env, "powershell.exe", mountOptions)
-	if err != nil {
-		return err
-	}
-
-	err = m.osutil.Remove(target)
-	if err != nil {
-		return err
-	}
-
-	mklinkOptions := []string{
-		"/c",
-		"mklink",
-		"/d",
-		target,
-		source,
-	}
-	_, err = m.invoker.Invoke(env, "cmd", mklinkOptions)
 	return err
 }
 


### PR DESCRIPTION
1709+ Windows cells don't necessarily have mklink installed by default, so instead delegate out to the mount.ps1 script to mount the volume _and_ create the link.

Note - This is dependent upon my other PR for the bosh smb-volume-release.