### PR TITLE
Fix `go get` now deprecated if not within a module

### DIFF
--- a/scripts/ci/run_docker_driver_integration_tests
+++ b/scripts/ci/run_docker_driver_integration_tests
@@ -30,7 +30,7 @@ apt-get update
 apt-get -y install cifs-utils realpath
 export GOROOT=/usr/local/go
 export PATH=$GOROOT/bin:/root/go/bin/:$PATH
-go get -u github.com/onsi/ginkgo/ginkgo
+go install github.com/onsi/ginkgo/ginkgo@latest
 
 pushd smbdriver
   listen_port=8589


### PR DESCRIPTION
[#181897822]