### PR TITLE
Match allowed mount options between driver and broker

### DIFF
--- a/smb_mounter_unix.go
+++ b/smb_mounter_unix.go
@@ -130,7 +130,8 @@ func (m *smbMounter) Purge(env dockerdriver.Env, path string) {
 }
 
 func NewSmbVolumeMountMask() (vmo.MountOptsMask, error) {
-	allowed := []string{"mfsymlinks", "username", "password", "file_mode", "dir_mode", "ro", "domain", "vers", "sec", "version"}
+	allowed := []string{"mfsymlinks", "username", "password", "file_mode", "dir_mode", "ro", "domain", "vers", "sec", "version",
+		"noserverino", "forceuid", "noforceuid", "forcegid", "noforcegid"}
 	defaultMap := map[string]interface{}{}
 
 	return vmo.NewMountOptsMask(


### PR DESCRIPTION
The broker now allows these options but they are denied by the driver

Signed-off-by: David Stevenson <stevensonda@vmware.com>