### PR TITLE
allow nodfs option

### DIFF
--- a/smb_mounter_unix.go
+++ b/smb_mounter_unix.go
@@ -138,7 +138,7 @@ func (m *smbMounter) Purge(env dockerdriver.Env, path string) {
 
 func NewSmbVolumeMountMask() (vmo.MountOptsMask, error) {
 	allowed := []string{"mfsymlinks", "username", "password", "file_mode", "dir_mode", "ro", "domain", "vers", "sec", "version",
-		"noserverino", "forceuid", "noforceuid", "forcegid", "noforcegid"}
+		"noserverino", "forceuid", "noforceuid", "forcegid", "noforcegid", "nodfs"}
 	defaultMap := map[string]interface{}{}
 
 	return vmo.NewMountOptsMask(


### PR DESCRIPTION
[#186402045]

dealing with a support case it was found that on newer kernels the mounting of some oracle zfs based shares via samba will fail without the nodfs option.

this can be addressed by whitelisting the nodfs options to be used in the underlying service bindings.