### PR TITLE
add forceNoDfs option

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,6 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.20'
+          go-version: '1.21'
       - uses: actions/checkout@v3
       - run: go run github.com/onsi/ginkgo/v2/ginkgo -r

--- a/cmd/smbdriver/main.go
+++ b/cmd/smbdriver/main.go
@@ -119,6 +119,24 @@ var forceNoserverino = flag.Bool(
 	"Force all SMB mounts to use the 'noserverino' mount flag, regardless of what the service binding asks for",
 )
 
+// The forceNoDfs option was added on 2024-01-09.
+//
+// We had seen a large deployment in which upgrading beyond jammy v1.199
+// stemcells caused all apps using SMB mounts to fail with:
+// "CIFS: VFS: cifs_mount failed w/return code = -19"
+// errors. This turned out to be because the kernel had a regression around
+// CIFS DFS handling.
+//
+// The fix was to re-bind the SMB service with the mount parameter
+// "nodfs". This option was intended to allow the platform operator to
+// apply that fix across the whole foundation, rather than relying on
+// application authors to re-bind their SMB services.
+var forceNoDfs = flag.Bool(
+	"forceNoDfs",
+	false,
+	"Force all smb mounts to use the 'nodfs' mount flag, regardless of what the service binding asks for",
+)
+
 const listenAddress = "127.0.0.1"
 
 func main() {
@@ -139,6 +157,7 @@ func main() {
 		&ioutilshim.IoutilShim{},
 		configMask,
 		*forceNoserverino,
+		*forceNoDfs,
 	)
 
 	client := volumedriver.NewVolumeDriver(

--- a/scripts/ci/run_docker_driver_integration_tests
+++ b/scripts/ci/run_docker_driver_integration_tests
@@ -30,7 +30,7 @@ apt-get update
 apt-get -y install cifs-utils 
 export GOROOT=/usr/local/go
 export PATH=$GOROOT/bin:/root/go/bin/:$PATH
-go install github.com/onsi/ginkgo/ginkgo@latest
+
 
 pushd smbdriver
   listen_port=8589
@@ -52,7 +52,7 @@ pushd smbdriver
     }
   } " > "${FIXTURE_FILENAME}"
 
-  go build -mod=vendor -o "/tmp/smbdriver" "cmd/smbdriver/main.go"
+  go build -o "/tmp/smbdriver" "cmd/smbdriver/main.go"
 
   mountDir="/tmp/mountdir"
   mkdir -p "${mountDir}"
@@ -63,5 +63,5 @@ pushd smbdriver
 popd
 
 pushd ${TEST_PACKAGE}
-  ginkgo -mod vendor -v -keepGoing . -race
+  go run github.com/onsi/ginkgo/v2/ginkgo -v --keep-going . -race
 popd


### PR DESCRIPTION
[#186806700]

a recent update to the jammy kernel seems to break smb mounts that would normally use DFS. This option is being added as a workaround for affected environments while the kernel fix is underway.