### PR TITLE
make the image that is used to start samba an input

### DIFF
--- a/scripts/ci/run_docker_driver_integration_tests
+++ b/scripts/ci/run_docker_driver_integration_tests
@@ -13,12 +13,16 @@ export DOCKER_HOST="tcp://${OUTER_CONTAINER_IP}:4243"
 
 start_docker "${certs_dir}"
 
+if [[ -d docker_image_samba_input ]]; then
+  docker load -i docker_image_samba_input/image.tar
+fi
+
 SMB_REMOTE_PATH="//localhost/example1"
 SMB_USERNAME="example1"
 SMB_PASSWORD="badpass"
 
 docker --tlsverify --tlscacert=${certs_dir}/ca.pem --tlscert=${certs_dir}/cert.pem --tlskey=${certs_dir}/key.pem \
-            run -it -p 139:139 -p 445:445 -d harbor-repo.vmware.com/dockerhub-proxy-cache/dperson/samba -p \
+            run -it -p 139:139 -p 445:445 -d ${SAMBA_IMAGE_NAME} -p \
             -u "$SMB_USERNAME;$SMB_PASSWORD" \
             -s "$SMB_USERNAME;/$SMB_USERNAME;no;no;no;$SMB_USERNAME" \
             -p \

--- a/scripts/ci/run_docker_driver_integration_tests.build.yml
+++ b/scripts/ci/run_docker_driver_integration_tests.build.yml
@@ -9,10 +9,14 @@ image_resource:
 inputs:
   - name: smbdriver
   - name: docker_driver_integration_tests
+  - name: docker_image_samba_input
+    optional: true
 
 params:
   TEST_PACKAGE: docker_driver_integration_tests
   BINDINGS_FILE: smb-bindings.json
+  SAMBA_IMAGE_NAME: dperson/samba
+  
 
 run:
   path: smbdriver/scripts/ci/run_docker_driver_integration_tests


### PR DESCRIPTION
this way the team that owns ci can preload it into the docker daemon that is started in the task.